### PR TITLE
Updated jquery.prettyLoader.js at lines #36,#37 to check for a error thrown by the plugin

### DIFF
--- a/js/jquery.prettyLoader.js
+++ b/js/jquery.prettyLoader.js
@@ -33,8 +33,8 @@
       		e = e ? e : window.event;
 
 			// Set the cursor pos only if the even is returned by the browser.
-			cur_x = (e.clientX) ? e.clientX : cur_x;
-			cur_y = (e.clientY) ? e.clientY : cur_y;
+			cur_x = (e.clientX) ? e.clientX : (typeof cur_x==='undefined'?0:cur_x);
+			cur_y = (e.clientY) ? e.clientY : (typeof cur_y==='undefined'?0:cur_y);
 
 			left_pos = cur_x + settings.offset_left + scrollPos['scrollLeft'];
 			top_pos = cur_y + settings.offset_top + scrollPos['scrollTop'];


### PR DESCRIPTION
Error - cur_x is not defined

Cause - When the mouse is positioned at a place not belonging to the clientarea. The event parameter does not contain clientX and clientY properties, both are not defined and thus the PrettyLoader plugins throws an error at line#36 and line#37.

Solution - TO correct this problem, I have added a simple condition that checks for such scenario.
